### PR TITLE
Add GitHub Pages workflow for static site deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Upload static files
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # surgmsk
+
 A reimaginging of the surgery and MSK content but in a more appealing way
+
+## GitHub Pages
+
+The repository includes a workflow that uploads the site to GitHub Pages. Any push to `main` will trigger the action defined in `.github/workflows/deploy.yml` and publish the current contents of the repository. After the workflow completes, the site will be available from the repository's **Pages** tab.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish static site to GitHub Pages
- document GitHub Pages deployment in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1942ebe588333b0489879ecd3ba00